### PR TITLE
Note about official badges available

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 
 ---
 
+> [!NOTE]
+> WakaTime has official total code time badges available from your [WakaTime profile](https://wakatime.com/me?badge=true).
+
 > [!IMPORTANT]
 > In order to display your statistics you need to host this API yourself, for this I recommend using [Cloudflare Workers](#️-hosting-with-cloudflare-workers)
 


### PR DESCRIPTION
We've had these available for some years now (since 2021). The readme should link to the official badges as an easier option without needing to boot up cloudflare workers.